### PR TITLE
Defines pow/2 for integers and integer square root isqrt/2. Also, improved documentation

### DIFF
--- a/lib/math.ex
+++ b/lib/math.ex
@@ -281,7 +281,7 @@ defmodule Math do
   def isqrt(x), do: _isqrt(x, 1, div((1 + x), 2))
     
   defp _isqrt(x, m, n) when abs(m - n) <= 1 and n * n <= x, do: n
-  defp _isqrt(x, m, n) when abs(m - n) <= 1, do: n - 1
+  defp _isqrt(_x, m, n) when abs(m - n) <= 1, do: n - 1
 
   defp _isqrt(x, _, n) do
     _isqrt(x, n, div(n + div(x, n), 2))

--- a/lib/math.ex
+++ b/lib/math.ex
@@ -3,34 +3,57 @@ defmodule Math do
   Mathematical functions and constants.
   """
 
-  # Arbitrary precision for "nearish". 1e-15
-  @epsilon 0.000000000000001
-  # Taken from Java's Float.MAX_VALUE
-  @max_value 3.4028234663852886e38
+  # For practical uses floats can be considered equal if their difference is less than this value. See <~>.
+  @epsilon 1.0e-15
+  
+  # Theoretical limit is 1.80e308, but Erlang errors at that value, so the practical limit is slightly below that one.
+  @max_value 1.79769313486231580793e308
 
   @type x :: number
   @type y :: number
 
+
   @doc """
-  The mathematical constant PI.
+  The mathematical constant *π* (pi).
+
+  The ratio of a circle's circumference to its diameter.
+  The returned number is a floating-point approximation (as π is irrational)
   """
   @spec pi :: float
   defdelegate pi, to: :math
 
+  @rad_in_deg (180/:math.pi)
+
+
   @doc """
-  The mathematical constant TAU.
+  The mathematical constant *τ* (tau).
+
+  The ratio of a circle's circumference to its radius.
+  Defined as 2 * π, but preferred by some mathematicians.
+  The returned number is a floating-point approximation (as τ is irrational)
   """
   @spec tau :: float
   def tau, do: pi * 2
 
   @doc """
-  The mathematical constant E (e).
+  The mathematical constant *ℯ* (e).
+
+
   """
   @spec e :: float
   def e, do: 2.718281828459045
 
   @doc """
-  Equality-ish test for whether x and y are nearly equal.
+  Equality-test for whether *x* and *y* are _nearly_ equal.
+
+  This is useful when working with floating-point numbers, as these introduce small rounding errors.
+
+  ## Examples
+
+      iex> 2.3 - 0.3 == 2.0
+      false
+      iex> 2.3 - 0.3 <~> 2.0
+      true 
   """
   @spec number <~> number :: boolean
   def x <~> y do
@@ -50,117 +73,218 @@ defmodule Math do
   end
 
   @doc """
-  Computes the sine of x.
+  Arithmetic exponentiation. Returns *x* to the *n* -th power.
+
+  When both *x* and *n* are integers and *n* is positive, returns an `integer`.
+  When *n* is a negative integer, returns a `float`.
+  When working with integers, the Exponentiation by Squaring algorithm is used, to allow for a fast and precise result.
+
+  When one of the numbers is a float, returns a `float` by using erlang's `:math.pow/2` function.
+
+  It is possible to calculate roots by choosing *n* between  0.0 and 1.0 (To calculate the *p* -th-root, pass 1/*p* to the function)  
+
+  ## Examples
+
+      iex> Math.pow(2, 4)
+      16
+      iex> Math.pow(2.0, 4)
+      16.0
+      iex> Math.pow(2, 4.0)
+      16.0
+      iex> Math.pow(5, 100)
+      7888609052210118054117285652827862296732064351090230047702789306640625
+      iex> Math.pow(5.0, 100)
+      7.888609052210118e69
+      iex> Math.pow(2, (1/2))
+      1.4142135623730951
+  """
+  @spec pow(number, number) :: number
+  def pow(x, n)
+
+  def pow(x, n) when is_integer(x) and is_integer(n), do: _pow(x, n)
+
+  # Float implementation. Uses erlang's math library.
+  def pow(x, n) do
+    :math.pow(x, n)
+  end
+
+  # Integer implementation. Uses Exponentiation by Squaring. 
+  defp _pow(x, n, y \\ 1)
+  defp _pow(_x, 0, y), do: y
+  defp _pow(x, 1, y), do: x * y
+  defp _pow(x, n, y) when (n < 0), do: _pow(1 / x, -n, y)
+  defp _pow(x, n, y) when rem(n, 2) == 0, do: _pow(x * x, div(n, 2), y)
+  defp _pow(x, n, y), do: _pow(x * x, div((n - 1), 2), x * y)
+
+  @doc """
+  Converts degrees to radians
+
+  ## Examples
+
+      iex>Math.deg2rad(180)
+      3.141592653589793
+      
+  """
+  @spec deg2rad(x) :: float
+  def deg2rad(x) do
+    x / @rad_in_deg
+  end
+
+
+  @doc """
+  Converts radians to degrees
+  
+  ## Examples
+
+      iex>Math.rad2deg(Math.pi)
+      180.0
+  """
+  @spec rad2deg(x) :: float
+  def rad2deg(x) do
+    x * @rad_in_deg
+  end
+
+  @doc """
+  Computes the sine of *x*.
+
+  *x* is interpreted as a value in radians.
   """
   @spec sin(x) :: float
   defdelegate sin(x), to: :math
 
   @doc """
-  Computes the cosine of x.
+  Computes the cosine of *x*.
+
+  *x* is interpreted as a value in radians.
   """
   @spec cos(x) :: float
   defdelegate cos(x), to: :math
 
   @doc """
-  Computes the tangent of x (expressed in radians).
+  Computes the tangent of *x* (expressed in radians).
   """
   @spec tan(x) :: float
   defdelegate tan(x), to: :math
 
   @doc """
-  Computes the arc sine of x.
+  Computes the arc sine of *x*. (expressed in radians)
   """
   @spec asin(x) :: float
   defdelegate asin(x), to: :math
 
   @doc """
-  Computes the arc cosine of x.
+  Computes the arc cosine of *x*. (expressed in radians)
   """
   @spec acos(x) :: float
   defdelegate acos(x), to: :math
 
   @doc """
-  Computes the arc tangent of x.
+  Computes the arc tangent of *x*. (expressed in radians)
   """
   @spec atan(x) :: float
   defdelegate atan(x), to: :math
 
   @doc """
-  Computes the arc tangent given y and x.
+  Computes the arc tangent given *y* and *x*. (expressed in radians)
   """
   @spec atan2(y, x) :: float
   defdelegate atan2(y, x), to: :math
 
   @doc """
-  Computes the hyperbolic sine of x (expressed in radians).
+  Computes the hyperbolic sine of *x* (expressed in radians).
   """
   @spec sinh(x) :: float
   defdelegate sinh(x), to: :math
 
   @doc """
-  Computes the hyperbolic cosine of x (expressed in radians).
+  Computes the hyperbolic cosine of *x* (expressed in radians).
   """
   @spec cosh(x) :: float
   defdelegate cosh(x), to: :math
 
   @doc """
-  Computes the hyperbolic tangent of x (expressed in radians).
+  Computes the hyperbolic tangent of *x* (expressed in radians).
   """
   @spec tanh(x) :: float
   defdelegate tanh(x), to: :math
 
   @doc """
-  Computes the inverse hyperbolic sine of x.
+  Computes the inverse hyperbolic sine of *x*.
   """
   @spec asinh(x) :: float
   defdelegate asinh(x), to: :math
 
   @doc """
-  Computes the inverse hyperbolic cosine of x.
+  Computes the inverse hyperbolic cosine of *x*.
   """
   @spec acosh(x) :: float
   defdelegate acosh(x), to: :math
 
   @doc """
-  Computes the inverse hyperbolic tangent of x.
+  Computes the inverse hyperbolic tangent of *x*.
   """
   @spec atanh(x) :: float
   defdelegate atanh(x), to: :math
 
   @doc """
-  Returns e to the xth power.
+  Returns ℯ to the xth power.
   """
   @spec exp(x) :: float
   defdelegate exp(x), to: :math
 
   @doc """
-  Returns the natural logarithm (base e) of x.
+  Returns the natural logarithm (base `ℯ`) of *x*.
+
+  See also `e/0`.
   """
   @spec log(x) :: float
   defdelegate log(x), to: :math
 
   @doc """
-  Returns the logarithm (base 2) of x.
+  Returns the binary logarithm (base `2`) of *x*.
   """
   @spec log2(x) :: float
   defdelegate log2(x), to: :math
 
   @doc """
-  Computes the logarithm (base 10) of x.
+  Computes the common logarithm (base `10`) of *x*.
   """
   @spec log10(x) :: float
   defdelegate log10(x), to: :math
 
   @doc """
-  Returns x to the yth power.
-  """
-  @spec pow(x, y) :: float
-  defdelegate pow(x, y), to: :math
-
-  @doc """
-  Returns the non-negative square root of x.
+  Returns the non-negative square root of *x*.
   """
   @spec sqrt(x) :: float
   defdelegate sqrt(x), to: :math
+
+  @doc """
+  Returns the non-negative integer square root of *x* (rounded towards zero)
+
+  Does not accept negative numbers as input.
+
+  ## Examples
+
+      iex> Math.isqrt(100)
+      10
+      iex> Math.isqrt(16)
+      4
+      iex> Math.isqrt(65536)
+      256
+      iex> Math.isqrt(10)
+      3
+  """
+  def isqrt(x)
+
+  def isqrt(x) when x < 0, do: raise ArithmeticError
+
+  def isqrt(x), do: _isqrt(x, 1, div((1 + x), 2))
+    
+  defp _isqrt(x, m, n) when abs(m - n) <= 1 and n * n <= x, do: n
+  defp _isqrt(x, m, n) when abs(m - n) <= 1, do: n - 1
+
+  defp _isqrt(x, _, n) do
+    _isqrt(x, n, div(n + div(x, n), 2))
+  end
 
 end

--- a/test/math_test.exs
+++ b/test/math_test.exs
@@ -1,5 +1,5 @@
 defmodule MathTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   import Math
   doctest Math
 
@@ -114,9 +114,27 @@ defmodule MathTest do
   end
 
   test "pow" do
-    assert pow(2, 2) <~> 4
-    assert pow(2, 3) <~> 8
-    assert pow(3, 3) <~> 27
+    # Integer powers
+    assert pow(2, 2) == 4
+    assert pow(2, 3) == 8
+    assert pow(3, 3) == 27
+    assert pow(2, 60) == 1152921504606846976
+    assert pow(256, 8) == 18446744073709551616
+
+    # Negative integer powers
+    assert pow(2, -2) <~> 0.25
+    assert pow(2, -2) <~> 0.25
+    assert pow(10, -8) <~> 1.0e-8
+
+    # Floating point
+    assert pow(2, 2.0) <~> 4.0
+    assert pow(2.0, 3) <~> 8.0
+
+    # Floating point powers with decimals
+    assert pow(2, (1/2) ) <~> sqrt(2)
+    assert pow(1000, (1/4) ) <~> sqrt(sqrt(1000))
+    assert pow(1000, (1/4) ) <~> sqrt(sqrt(1000))
+
   end
 
   test "sqrt" do
@@ -125,5 +143,17 @@ defmodule MathTest do
     Enum.each(1..10, fn(x) ->
       assert sqrt(pow(x, 2)) <~> x
     end)
+  end
+
+  test "isqrt" do
+    assert isqrt(0) == 0
+    assert isqrt(1) == 1
+    assert isqrt(9) == 3
+    assert isqrt(10) == 3
+    assert isqrt(100) == 10
+    assert isqrt(65535) == 255
+    assert isqrt(65536) == 256
+    assert isqrt(15241578780673678546105778281054720515622620750190521) == 123456789123456789123456789
+    assert_raise ArithmeticError, fn -> isqrt(-2) end
   end
 end


### PR DESCRIPTION
I believe that the Math library will become more useful if it provides more than just wrapping erlang's `:math` functionalities. So, I went ahead and defined the following new functions:

- `pow/2` now uses the Exponentiation by Squaring algorithm to return integer results whenever possible.
- `isqrt/2` is a new function that computes the integer square root of a given integer.

These two implementations are obviously both unbound by the restrictions of floating-point precision.

Other changes in this Pull-Request are:

- `deg2rad/1` and `rad2deg/1` functions.
- Changed `@max_value` to reflect the actual max_value enforced by Erlang (just below the IEEE 754-1985 double precision 64 bits value)
- Improved documentation