### PR TITLE
Fixed Math.Enum.median for lists with even number of items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The Math module adds many useful functions that extend Elixir's standard library
   - `Math.asinh(x)` The inverse hyperbolic sine of *x*.
   - `Math.acosh(x)` The inverse hyperbolic cosine of *x*.
   - `Math.atanh(x)` The inverse hyperbolic tangent of *x*.
-  
+
 - Working with Collections
   - `Math.Enum.product(collection)` The result of multiplying all elements in the passed collection.
   - `Math.Enum.mean(collection)` the mean of the numbers in the collection.
@@ -54,14 +54,14 @@ Math is [available in Hex](https://hex.pm/packages/math). The package can be ins
 
         def deps do
           [
-            {:math, "~> 0.1.0"}
+            {:math, "~> 0.3.0"}
           ]
         end
 
   2. Require or import the Math library anywhere in your code you'd like:
 
         require Math
-    
+
   or
 
         import Math
@@ -69,6 +69,7 @@ Math is [available in Hex](https://hex.pm/packages/math). The package can be ins
   (Importing allows usage of the `<~>` operator)
 
 ## Changelog
+- 0.3.0 Fixed incorrect median for lists with even number of items. Updated tests.
 - 0.2.0 Added `factorial/1`, `nth_sqrt/2`, `k_permutations/2`, `k_combinations/2`, `gcd/2`, `lcm/2` and `Math.Enum` functions. Improved documentation.
 - 0.1.0 Added integer variant of `pow/1`, `isqrt/2`, `deg2rad/1`, `rad2deg/1`. Improved documentation.
 - 0.0.1 First implementation, mostly a wrapper around Erlang's `:math` library.

--- a/lib/math/enum.ex
+++ b/lib/math/enum.ex
@@ -24,14 +24,14 @@ defmodule Math.Enum do
   end
 
   @doc """
-  Calculates the mean of a collection of numbers. 
+  Calculates the mean of a collection of numbers.
 
   This is the sum, divided by the amount of elements in the collection.
 
   If the collection is empty, returns `nil`
 
   Also see `Math.Enum.median/1`
-  
+
   ## Examples
       iex> Math.Enum.mean [1,2,3]
       2.0
@@ -46,7 +46,7 @@ defmodule Math.Enum do
   def mean(collection)
 
   def mean(collection) do
-    count = Enum.count(collection) 
+    count = Enum.count(collection)
     case count do
       0 -> nil
       _ -> Enum.sum(collection) / count
@@ -68,9 +68,11 @@ defmodule Math.Enum do
       iex> Math.Enum.median [1,2,3]
       2
       iex> Math.Enum.median 1..10
-      6.5
+      5.5
       iex> Math.Enum.median [1,2,3,4,5, -100]
-      3.5
+      2.5
+      iex> Math.Enum.median [1,2]
+      1.5
       iex> Math.Enum.median []
       nil
   """
@@ -78,17 +80,17 @@ defmodule Math.Enum do
   def median(collection)
 
   def median(collection) do
-    count = Enum.count(collection) 
+    count = Enum.count(collection)
     cond do
       count == 0 -> nil
       rem(count, 2) == 1 -> # Middle element exists
         Enum.sort(collection) |> Enum.at(div(count, 2))
       true ->
-        # Take two middle-most elements. 
+        # Take two middle-most elements.
         sorted_collection = Enum.sort(collection)
         [
-          Enum.at(sorted_collection, div(count, 2)), 
-          Enum.at(sorted_collection, div(count, 2) + 1)
+          Enum.at(sorted_collection, div(count, 2)),
+          Enum.at(sorted_collection, div(count, 2) - 1)
         ]
         |> Math.Enum.mean
     end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Math.Mixfile do
 
   def project do
     [app: :math,
-     version: "0.2.0",
+     version: "0.3.0",
      elixir: "~> 1.2",
      description: description,
      package: package,


### PR DESCRIPTION
Math.Enum.median was not taking into account that list indexes are base zero.