### PR TITLE
Fix warnings in mix.exs for 'variable does not exist'

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,9 +5,9 @@ defmodule Math.Mixfile do
     [app: :math,
      version: "0.3.0",
      elixir: "~> 1.2",
-     description: description,
-     package: package,
-     deps: deps,
+     description: description(),
+     package: package(),
+     deps: deps(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod]
   end


### PR DESCRIPTION
This resolves the following warnings:

```
warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:8

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:9

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:10
```