### PR TITLE
Update dependencies & clean up mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Math.Mixfile do
 
   def project do
     [app: :math,
-     version: "0.3.0",
+     version: "0.3.1",
      elixir: "~> 1.2",
      description: description(),
      package: package(),
@@ -72,7 +72,7 @@ defmodule Math.Mixfile do
 
   defp package do
     [
-      maintainers: ["Rodney Folz"],
+      maintainers: ["Rodney Folz", "Wiebe-Marten Wijnja/Qqwy"],
       licenses: ["Apache-2.0"],
       links: %{"GitHub": "https://github.com/folz/math"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -21,52 +21,7 @@ defmodule Math.Mixfile do
 
   defp description do
     """
-    The Math module adds many useful functions that extend Elixir's standard library.
-
-    - General Functions
-      • a <~> b Comparison of floats, to check if they are _nearly_ equal.
-      • Math.pow(x, n) Arithmetic exponentiation. Works both with integer powers and floats.
-      • Math.sqrt(x) The square root of x.
-      • Math.nth_root(x, n) The n-th root of x.
-      • Math.isqrt(x)  The integer square root of x.
-      • Math.gcd(a, b) The greatest common divisor of a and b.
-      • Math.lcm(a, b) The least common multiple of a and b.
-      • Math.factorial(n) The n-th factorial number.
-      • Math.k_permutations(n, k) The number of distinct ways to create groups of size k from n distinct elements.
-      • Math.k_combinations(n, k) The number of distinct ways to create groups of size k from n distinct elements where order does not matter.
-
-
-    - Logarithms
-      • Math.exp(x) Calculates ℯ to the xth power.
-      • Math.log(x) Calculates the natural logarithm (base ℯ) of x.
-      • Math.log(x, b) Calculates the base-b logarithm of x
-      • Math.log2(x) Calculates the binary logarithm (base 2) of x.
-      • Math.log10(x) Calculates the common logarithm (base 10) of x.
-      • Math.e Returns a floating-point approximation of the number ℯ.
-
-    - Trigonometry
-      • Math.pi Returns a floating-point approximation of the number π.
-      • Math.deg2rad(x) converts from degrees to radians.
-      • Math.rad2deg(x) converts from radians to degrees.
-      • Math.sin(x) The sine of x.
-      • Math.cos(x) The cosine of x.
-      • Math.tan(x) The tangent of x.
-      • Math.asin(x) The inverse sine of x.
-      • Math.acos(x) The inverse cosine of x.
-      • Math.atan(x) The inverse tangent of x.
-      • Math.atan2(x, y) The inverse tangent of x and y. This variant returns the inverse tangent in the correct quadrant, as the signs of both x and y are known.
-      • Math.sinh(x) The hyperbolic sine of x.
-      • Math.cosh(x) The hyperbolic cosine of x.
-      • Math.tanh(x) The hyperbolic tangent of x.
-      • Math.asinh(x) The inverse hyperbolic sine of x.
-      • Math.acosh(x) The inverse hyperbolic cosine of x.
-      • Math.atanh(x) The inverse hyperbolic tangent of x.
-
-    - Working with Collections
-      • Math.Enum.product(collection) The result of multiplying all elements in the passed collection.
-      • Math.Enum.mean(collection) the mean of the numbers in the collection.
-      • Math.Enum.median(collection) the median of the numbers in the collection.
-
+    The Math library extends Elixir with many common math-related functions, constants and (optionally) operators.
     """
   end
 
@@ -78,15 +33,6 @@ defmodule Math.Mixfile do
     ]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
   defp deps do
     [
       {:ex_doc, ">= 0.11.4", only: [:dev]}

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,7 @@
-%{"ex_doc": {:hex, :ex_doc, "0.11.4"}}
+%{
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
+}

--- a/test/math_test.exs
+++ b/test/math_test.exs
@@ -19,32 +19,32 @@ defmodule MathTest do
 
   test "sin" do
     assert sin(0) <~> 0
-    assert sin(pi/2) <~> 1
-    assert sin(pi) <~> 0
+    assert sin(pi()/2) <~> 1
+    assert sin(pi()) <~> 0
   end
 
   test "cos" do
     assert cos(0) <~> 1
-    assert cos(pi/2) <~> 0
-    assert cos(pi) <~> -1
+    assert cos(pi()/2) <~> 0
+    assert cos(pi()) <~> -1
   end
 
   test "tan" do
     assert tan(0) <~> 0
     # FIXME elixir can't handle infinity
     # assert tan(pi/2) <~> :infinity
-    assert tan(pi) <~> 0
+    assert tan(pi()) <~> 0
   end
 
   test "asin" do
     assert asin(0) <~> 0
-    assert asin(1) <~> pi/2
+    assert asin(1) <~> pi()/2
   end
 
   test "acos" do
-    assert acos(0) <~> pi/2
+    assert acos(0) <~> pi()/2
     assert acos(1) <~> 0
-    assert acos(-1) <~> pi
+    assert acos(-1) <~> pi()
 
     # The following are outside the domain of the inverse cosine
     assert_raise(ArithmeticError, fn -> acos(-1.1) end)
@@ -53,13 +53,13 @@ defmodule MathTest do
 
   test "atan" do
     assert atan(0) <~> 0
-    assert atan(1) <~> pi/4
+    assert atan(1) <~> pi()/4
   end
 
   test "atan2" do
     assert atan2(0, 1) <~> 0
-    assert atan2(1, 0) <~> pi/2
-    assert atan2(1, 1) <~> pi/4
+    assert atan2(1, 0) <~> pi()/2
+    assert atan2(1, 1) <~> pi()/4
   end
 
   test "sinh" do
@@ -106,13 +106,13 @@ defmodule MathTest do
 
   test "exp" do
     assert exp(0) <~> 1
-    assert exp(1) <~> e
+    assert exp(1) <~> e()
     assert exp(log(2)) <~> 2
   end
 
   test "log" do
     assert log(1) <~> 0
-    assert log(e) <~> 1
+    assert log(e()) <~> 1
     assert log(exp(2)) <~> 2
   end
 


### PR DESCRIPTION
This PR cleans up the code to make it work without warnings on newer Elixir-versions.
It also cleans up `mix.exs` to play well with the changes in Mix and Hex.PM over the years.