### PR TITLE
Update supported Elixir versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ elixir:
   - 1.7.4
   - 1.8.2
   - 1.9.4
-  - 1.10.0
 after_script:
   - MIX_ENV=docs mix deps.get
   - MIX_ENV=docs mix inch.report

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ elixir:
   - 1.7.4
   - 1.8.2
   - 1.9.4
+  - 1.10.0
 after_script:
   - MIX_ENV=docs mix deps.get
   - MIX_ENV=docs mix inch.report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: elixir
 elixir:
-  - 1.3.4
   - 1.4.5
   - 1.5.3
   - 1.6.6


### PR DESCRIPTION
* Removes v1.3.4 from supported versions, as `Enum.max_by/3` was added in v1.4.

This PR "removes" support for v1.3.4, which reflects a failing test that we missed because CI wasn't correctly configured when PR #15 was merged. I think this is acceptable because Elixir 1.3 is no longer supported according to the [Compatibility and Deprecations](https://hexdocs.pm/elixir/1.10.0/compatibility-and-deprecations.html) page.

This PR originally added v1.10.0 to the supported versions but I ran into [issues with compatibility](https://travis-ci.org/folz/math/jobs/643088331) between Erlang/OTP and Elixir versions, so I'll keep that change out of this PR.