### PR TITLE
Changed Math.Enum.mean/1 to require a single pass over the enumerable

### DIFF
--- a/lib/math/enum.ex
+++ b/lib/math/enum.ex
@@ -47,12 +47,12 @@ defmodule Math.Enum do
   def mean(collection)
 
   def mean(collection) do
-    count = Enum.count(collection)
-
-    case count do
-      0 -> nil
-      _ -> Enum.sum(collection) / count
-    end
+    collection
+    |> Enum.reduce({nil, 0}, fn
+      elem, {nil, 0} -> {elem, 1}
+      elem, {mean, count} -> {(mean * count + elem) / (count + 1), count + 1}
+    end)
+    |> elem(0)
   end
 
   @doc """

--- a/lib/math/enum.ex
+++ b/lib/math/enum.ex
@@ -43,7 +43,7 @@ defmodule Math.Enum do
       iex> Math.Enum.mean []
       nil
   """
-  @spec mean(Enum.t()) :: number
+  @spec mean(Enum.t()) :: number | nil
   def mean(collection)
 
   def mean(collection) do

--- a/lib/math/enum.ex
+++ b/lib/math/enum.ex
@@ -49,7 +49,7 @@ defmodule Math.Enum do
   def mean(collection) do
     collection
     |> Enum.reduce({nil, 0}, fn
-      elem, {nil, 0} -> {elem, 1}
+      elem, {nil, 0} -> {elem * 1.0, 1}
       elem, {mean, count} -> {(mean * count + elem) / (count + 1), count + 1}
     end)
     |> elem(0)


### PR DESCRIPTION
Currently, `Math.Enum.mean/1` requires two passes to calculate the mean of the `Enumerable`. This commit changes the function to require only a single pass by using `Enum.reduce/3` to calculate a running-mean.